### PR TITLE
Update dependency from missing repo

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,7 +13,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/kless/goconfig/config"
+	"github.com/jurka/goconfig/config"
 	"os"
 	"path/filepath"
 	"syscall"


### PR DESCRIPTION
Looks like @kless' goconfig repo disappeared. I found a fork, and things seem to build and behave OK on that fork.

Let me know if I'm totally cracked here...I'm rather new to Go and it's world view.
