### PR TITLE
Removed absolute path validation for ExternalTemplate

### DIFF
--- a/config/gonew_config.go
+++ b/config/gonew_config.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bmatsuo/go-validate"
 	"io/ioutil"
 	"os"
-	"strings"
 )
 
 type configInheritanceGraph map[string]map[string]interface{}
@@ -111,9 +110,7 @@ type ExternalTemplate string
 func (config ExternalTemplate) Validate() (err error) {
 	path := string(config)
 	var info os.FileInfo
-	if !strings.HasPrefix(path, "/") {
-		return errors.New("relative path " + path)
-	} else if info, err = os.Stat(path); err != nil {
+	if info, err = os.Stat(path); err != nil {
 		return
 	} else if !info.IsDir() {
 		return errors.New("not a directory " + path)


### PR DESCRIPTION
It seems that absolute path validation in this section is a little redundant.
As long as there is a check that the directory exists.
